### PR TITLE
Modified htmerl_sax_utf8 to condense multiple whitespace characters.

### DIFF
--- a/src/htmerl_sax_utf8.erl
+++ b/src/htmerl_sax_utf8.erl
@@ -2995,12 +2995,14 @@ add_text_chars(C, #{text_node_buff := Buff} = State) ->
 maybe_pop_text(#{text_node_buff := undefined} = State) ->
    State;
 maybe_pop_text(#{text_node_buff := Buff} = State) ->
-   case maps:get(last_start_tag, State) of 
-      {start_tag, <<"pre">>, _, _} ->
-        Event = {characters, u(Buff)},
-        State1 = send_event(Event, State),
-        State1#{text_node_buff := undefined};
-      _ ->
+   TestFun = fun(X) -> {start_tag, Y, _, _} = X, Y =:= <<"pre">> end,
+   HasPre = lists:any(TestFun, maps:get(open_elements, State)),
+   if
+      HasPre -> 
+         Event = {characters, u(Buff)},
+         State1 = send_event(Event, State),
+         State1#{text_node_buff := undefined};
+      true ->
         Buff1 = norm_whitespaces(Buff),
         Event = {characters, u(Buff1)},
         State1 = send_event(Event, State),

--- a/src/htmerl_sax_utf8.erl
+++ b/src/htmerl_sax_utf8.erl
@@ -72,11 +72,13 @@ string(Bin, Options) ->
 
 norm_whitespaces(Bin) ->
    Splitted = binary:split(Bin, [<<"\n">>, <<" ">>, <<"\t">>], [global, trim_all]),
-   list_to_binary(combine(Splitted, " ")).
+   IOList = combine(Splitted, <<" ">>),
+   iolist_to_binary(IOList).
 
 combine([], _) -> "" ;
+combine([Last], _) -> [Last];
 combine([Head|Tail], Space) -> 
-   binary_to_list(Head) ++ Space ++ combine(Tail, Space).
+   [Head, Space, combine(Tail, Space)].
 
 norm_newlines(Bin, _) ->
    binary:replace(Bin, [<<$\r,$\n>>, <<$\r>>], <<$\n>>, [global]).

--- a/src/htmerl_sax_utf8.erl
+++ b/src/htmerl_sax_utf8.erl
@@ -68,7 +68,16 @@ string(Bin, Options) ->
         end,
    M3 = maps:merge(default_state(), M2),
    Bin1 = norm_newlines(Bin, <<>>),
-   data(Bin1, M3).
+   Bin2 = norm_whitespaces(Bin1),
+   data(Bin2, M3).
+
+norm_whitespaces(Bin) ->
+   Splitted = binary:split(Bin, [<<"\n">>, <<" ">>, <<"\t">>], [global, trim_all]),
+   list_to_binary(combine(Splitted, " ")).
+
+combine([], _) -> "" ;
+combine([Head|Tail], Space) -> 
+   binary_to_list(Head) ++ Space ++ combine(Tail, Space).
 
 norm_newlines(Bin, _) ->
    binary:replace(Bin, [<<$\r,$\n>>, <<$\r>>], <<$\n>>, [global]).


### PR DESCRIPTION
I modified it so that it follows the html standard better. Html parsers are supposed condense spaces, new lines, and tabs.