### PR TITLE
Fix when an element appears with no body

### DIFF
--- a/src/htmerl_sax_utf8.erl
+++ b/src/htmerl_sax_utf8.erl
@@ -2136,6 +2136,13 @@ dispatch(#{insertion_mode := after_head} = State, Token) ->
         #end_tag{} ->
             % parse error
             State;
+        #start_tag{} ->
+            % A tag was started without a body. Report body and the tag opened.
+            State1 = maybe_pop_text(State),
+            Token1 = #start_tag{name = <<"body">>},
+            State2 = add_html_element(Token1, State1),
+            State3 = add_html_element(Token, State2),
+            State3#{insertion_mode := in_body};
         _ ->
             State1 = maybe_pop_text(State),
             Token1 = #start_tag{name = <<"body">>},


### PR DESCRIPTION
The first element in a document that has no body tag would report its text before the opening tag.

Resolves #4