### PR TITLE
Empty attributes have empty string as their value

### DIFF
--- a/src/htmerl_sax_utf8.erl
+++ b/src/htmerl_sax_utf8.erl
@@ -952,8 +952,8 @@ after_attribute_name(<<>>, State) ->
     % fatal parse error
     emit(eof, State);
 after_attribute_name(Stream, #{current_token := Curr} = State) ->
-    [#attribute{name = AName} = Ca | Atts0] = Curr#start_tag.attributes,
-    Atts = [#attribute{} | [Ca#attribute{value = AName} | Atts0]],
+    % Empty attribute, leave the value empty (previous versions set the value to the attribute name).
+    Atts = [#attribute{} | Curr#start_tag.attributes],
     attribute_name(Stream, State#{current_token := Curr#start_tag{attributes = Atts}}).
 
 %% 8.2.4.35


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/syntax.html#attributes-2

Fixes #9 